### PR TITLE
Typo and formatting fixes

### DIFF
--- a/03-SummarizingData.Rmd
+++ b/03-SummarizingData.Rmd
@@ -307,7 +307,7 @@ nhanes_slice <- NHANES_adult %>%
   dplyr::select(Height) %>%
   slice(45:50) 
 
-kable(nhanes_slice, caption='A few values from the NHANES data frame.', digits=1)
+kable(nhanes_slice %>% mutate(Height=formatC(Height, digits=1, format='f')), caption='A few values from the NHANES data frame.', digits=1)
 ```
 
 Panel C of Figure \@ref(fig:heightHistSep) shows a histogram that counts the density of each possible value. That histogram looks really jagged, which is because of the variability in specific decimal place values.  For example, the value 173.2 occurs `r I(sum(NHANES_adult$Height==173.2,na.rm=TRUE))` times, while the value 173.3 only occurs `r I(sum(NHANES_adult$Height==173.3,na.rm=TRUE))` times. We probably don't think that there is really such a big difference between the prevalence of these two heights; more likely this is just due to random variability in our sample of people.  

--- a/05-FittingModels.Rmd
+++ b/05-FittingModels.Rmd
@@ -525,7 +525,7 @@ incomeDf <-
 ```
 
 ```{r echo=FALSE}
-kable(incomeDf %>% mutate(income=format(income, digits=0)), caption='Income for our five bar patrons plus Beyoncé Knowles.')
+kable(incomeDf %>% mutate(income=format(income, scientific=FALSE)), caption='Income for our five bar patrons plus Beyoncé Knowles.')
 
 ```
 

--- a/06-Probability.Rmd
+++ b/06-Probability.Rmd
@@ -145,10 +145,10 @@ $$
 
 For the six-sided die, the probability of each individual outcome is 1/6. 
 
-This is nice, but de Méré was interested in more complex events, like what happens on multiple dice throws.  How do we compute the probability of a complex event (which is a *union* of single events), like rolling a one on the first *or* the second throw?  
-We represent the union of events mathematically using the $\cup$ symbol: for example, if the probability of rolling a one on the first throw is referred to as $P(Roll1_{throw1})$ and the probability of rolling a one on the second throw is $P(Roll1_{throw2})$, then the union is referred to as $P(Roll1_{throw1} \cup Roll1_{throw2})$.
+This is nice, but de Méré was interested in more complex events, like what happens on multiple dice throws.  How do we compute the probability of a complex event (which is a *union* of single events), like rolling a six on the first *or* the second throw?  
+We represent the union of events mathematically using the $\cup$ symbol: for example, if the probability of rolling a six on the first throw is referred to as $P(Roll1_{throw1})$ and the probability of rolling a six on the second throw is $P(Roll1_{throw2})$, then the union is referred to as $P(Roll1_{throw1} \cup Roll1_{throw2})$.
 
-de Méré thought (incorrectly, as we will see below) that he could simply add together the probabilities of the individual events to compute the probability of the combined event, meaning that the probability of rolling a one on the first or second roll would be computed as follows:
+de Méré thought (incorrectly, as we will see below) that he could simply add together the probabilities of the individual events to compute the probability of the combined event, meaning that the probability of rolling a six on the first or second roll would be computed as follows:
 
 $$
 P(Roll1_{throw1}) = 1/6
@@ -429,7 +429,7 @@ P_diabetes_given_inactive <-
 # P_diabetes_given_inactive
 ```
 
-Based on these joint probabilities, we can compute $P(diabetes|inactive)$.  One way oo do this in a computer program is to first determine the whether the PhysActive variable was equal to "No" for each indivdual, and then take the mean of those truth values.  Since TRUE/FALSE values are treated as 1/0 respectively by most programming languages (including R and Python), this allows us to easily identify the probability of a simple event by simply taking the mean of a logical variable representing its truth value. We then use that value to compute the conditional probability, where we find that the probability of someone having diabetes given that they are physically inactive is `r I(sprintf('%0.3f',P_diabetes_given_inactive))`.
+Based on these joint probabilities, we can compute $P(diabetes|inactive)$.  One way to do this in a computer program is to first determine the whether the PhysActive variable was equal to "No" for each indivdual, and then take the mean of those truth values.  Since TRUE/FALSE values are treated as 1/0 respectively by most programming languages (including R and Python), this allows us to easily identify the probability of a simple event by simply taking the mean of a logical variable representing its truth value. We then use that value to compute the conditional probability, where we find that the probability of someone having diabetes given that they are physically inactive is `r I(sprintf('%0.3f',P_diabetes_given_inactive))`.
 
 ## Independence
 

--- a/11-BayesianStatistics.Rmd
+++ b/11-BayesianStatistics.Rmd
@@ -307,7 +307,7 @@ In some cases the credible interval can be computed *numerically* based on a kno
 
 ### Effects of different priors
 
-In the previous example we used a *flat prior*, meaning that we didn't have any reason to believe that any particular value of $p_{respond}$ was more or less likely.  However, let's say that we had instead started with some previous data: In a previous study, researchers had tested 20 people and found that 10 of them had responded positively.  This would have lead us to start with a prior belief that the treatment has an effect in 50% of people.  We can do the same computation as above, but using the information from our previous study to inform our prior (see oanel A in Figure \@ref(fig:posteriorDistPrior)).  
+In the previous example we used a *flat prior*, meaning that we didn't have any reason to believe that any particular value of $p_{respond}$ was more or less likely.  However, let's say that we had instead started with some previous data: In a previous study, researchers had tested 20 people and found that 10 of them had responded positively.  This would have lead us to start with a prior belief that the treatment has an effect in 50% of people.  We can do the same computation as above, but using the information from our previous study to inform our prior (see panel A in Figure \@ref(fig:posteriorDistPrior)).  
 
 ```{r ,echo=FALSE}
 

--- a/15-ComparingMeans.Rmd
+++ b/15-ComparingMeans.Rmd
@@ -191,7 +191,7 @@ To compute the standard errors for this analysis, we can use exactly the same eq
 The most commonly used effect size for a comparison between two means is Cohen's d, which (as you may remember from Chapter \@ref(ci-effect-size-power)) is an expression of the effect size in terms of standard deviation units.  For the t-test estimated using the general linear model outlined above (i.e. with a single dummy-coded variable), this is expressed as:
 
 $$
-d = \frac{\hat{beta_1}}{\sigma_{residual}}
+d = \frac{\hat{\beta_1}}{\sigma_{residual}}
 $$
 We can obtain these values from the analysis output above, giving us a d = `r I(sprintf('%0.2f', lm_summary$coefficients[2,1]/lm_summary$sigma))`, which we would generally interpret as a medium sized effect.
 

--- a/15-ComparingMeans.Rmd
+++ b/15-ComparingMeans.Rmd
@@ -262,7 +262,7 @@ t.test(
 )
 ```
 
-This analysis shows no significant difference. However, this analysis is inappropriate since it assumes that the two samples are independent, when in fact they are not, since the data come from the same individuals.  We can plot the data with a line for each individual to show this (see Figure \@ref(fig:BPLinePlot)).
+This analysis shows no significant difference. However, this analysis is inappropriate since it assumes that the two samples are independent, when in fact they are not, since the data come from the same individuals.  We can plot the data with a line for each individual to show this (see Figure \@ref(fig:BPfig)).
 
 In this analysis, what we really care about is whether the blood pressure for each person changed in a systematic way between the two measurements, so another way to represent the data is to compute the difference between the two timepoints for each individual, and then analyze these difference scores rather than analyzing the individual measurements. In Figure \@ref(fig:BPDiffHist), we show a histogram of these difference scores, with a blue line denoting the mean difference.
 

--- a/16-PracticalExamples.Rmd
+++ b/16-PracticalExamples.Rmd
@@ -173,7 +173,7 @@ Note that the software automatically generated dummy variables that correspond t
 
 The first thing we want to do is to critique the model to make sure that it is appropriate. One thing we can do is to look at the residuals from the model. In Figure \@ref(fig:residualPlot), we plot the residuals for each individual grouped by diet. There are no obvious differences in the distributions of residuals across conditions, we can go ahead with the analysis.
 
-```{r residualPlot, echo=FALSE, fig.width=4, fig.height=4}
+```{r residualPlot, echo=FALSE, fig.cap="Distribution of residuals for for each condition", fig.width=4, fig.height=4}
 dietDf <- dietDf %>%
   mutate(lmResid=lmResult$residuals)
 
@@ -182,10 +182,10 @@ ggplot(dietDf, aes(x=lmResid, group=diet, color=diet)) +
   xlab('Residuals')
 ```
 
-Another important assumption of the statistical tests that we apply to linear models is that the residuals from the model are normally distributed. The right panel of Figure \@ref(fig:diagnosticsPlot) shows a Q-Q (quantile-quantile) plot, which plots the residuals against their expected values based on their quantiles in the normal distribution. If the residuals are normally distributed then the data points should fall along the dashed line --- in this case it looks pretty good, except for a couple of outliers that are apparent here.  Because this model is also relatively robust to violations of normality, and these are fairly small, we will go ahead and use the results.
+Another important assumption of the statistical tests that we apply to linear models is that the residuals from the model are normally distributed. The right panel of Figure \@ref(fig:diagnosticQQPlot) shows a Q-Q (quantile-quantile) plot, which plots the residuals against their expected values based on their quantiles in the normal distribution. If the residuals are normally distributed then the data points should fall along the dashed line --- in this case it looks pretty good, except for a couple of outliers that are apparent here.  Because this model is also relatively robust to violations of normality, and these are fairly small, we will go ahead and use the results.
 
 
-```{r diagnosticQQPlot, echo=FALSE, fig.width=4, fig.height=4}
+```{r diagnosticQQPlot, echo=FALSE, fig.cap="Q-Q plot of actual residual values against theoretical residual values", fig.width=4, fig.height=4}
 
 ggplot(dietDf, aes(sample = lmResid)) +
   stat_qq() + stat_qq_line()


### PR DESCRIPTION
Thanks for the wonderful book! I was reading through the book for a course and found a few minor errors in the book, which I hope to fix in this pull request:

1. Typos
- Chapter 6.2.3: all `rolling a one` should be `rolling a six`, since the events we are betting on are about rolling sixes
- Chapter 6.5: `one way oo to this` should be `one way to do this`
- Chapter 11.4.8: `oanel A` should be `panel A`

2. Figure referencing problems
- Chapter 15.5: reference name `BPLinePlot` should be `BPfig`
- Chapter 16.1.6: two figure references did not work because the figures had no caption (I just added simple captions for them); also the second reference `diagnosticsPlot` should be `diagnosticQQPlot`

3. Formatting issues
- Chapter 5.5: income values are displayed as `%#4.0-1e` in browser (Chrome and IE), and in scientific format when knitted in RStudio. Simply disabling scientific notation causes the knitted gitbook to display the income values properly for me. I'm not sure if this helps the final rendering in browser as I was not able to get the docker container builder yet.
- Chapter 15.3.1: a slash is missing for beta (`beta` should be `\beta`)

4. Chapter 3.2.4
Table 3.4 is supposed to show that height was measured in centimeters down to the first decimal place, but the decimal place is not actually displayed (possibly because it's not considered significant). Setting `format='f'` with `formatC` should force the first decimal place to always be displayed.