### PR TITLE
Minor fix of latent variable of causal graphs (ch 13)

### DIFF
--- a/13-ContinuousRelationships.Rmd
+++ b/13-ContinuousRelationships.Rmd
@@ -22,6 +22,8 @@ library(knitr)
 library(DiagrammeR)
 library(htmltools)
 library(webshot)
+library(DiagrammeRsvg)
+library(rsvg)
 
 set.seed(123456) # set random seed to exactly replicate results
 
@@ -259,9 +261,10 @@ digraph boxes_and_circles {
 }
 "
 
-foo <- html_print(add_mathjax(grViz(graph))) %>%
-  webshot(file = 'images/dag_example.png', delay = 10,
-          selector = '.html-widget-static-bound')
+grViz(graph) %>% 
+   export_svg %>% 
+   charToRaw %>% 
+   rsvg_png("images/dag_example.png", width = 500)
 
 latent_graph = "
 digraph boxes_and_circles {
@@ -275,7 +278,13 @@ digraph boxes_and_circles {
         fixedsize = true,
         width = 0.9,
         fontsize=6] // sets as circles
-  StudyTime; ExamGrade; FinishTime; Knowledge
+  StudyTime; ExamGrade; FinishTime
+  
+  node [shape = box,
+        fixedsize = true,
+        width = 0.9,
+        fontsize=6] //  
+  Knowledge
 
   # several 'edge' statements
   StudyTime->Knowledge [color=green]
@@ -283,9 +292,10 @@ digraph boxes_and_circles {
   Knowledge->FinishTime [color=red]
 }
 "
-foo <- html_print(add_mathjax(grViz(latent_graph))) %>%
-  webshot(file = 'images/dag_latent_example.png', delay = 10,
-          selector = '.html-widget-static-bound')
+grViz(latent_graph) %>% 
+   export_svg %>% 
+   charToRaw %>% 
+   rsvg_png("images/dag_latent_example.png", width = 500)
 
 ```
 


### PR DESCRIPTION
In the example of causal graphs, I changed the latent variable ('Knowledge') into a box, as the caption described. (May be better to switch symbols between manifest and latent variables to better match some areas where that is customary, like structural equation modelling?)

Building the book with this change didn't update the graphs, because it was using the image files previously created. When I fixed the code to save the new graphs (using webshot function), it crashed. Could not make it work (error with the "selector" option), so I found another way to save the DiagrammeR graphs into image files using "export_svg %>% charToRaw %>% rsvg_png" functions. Though I'm not sure if this would work with the automated building (maybe just updating the file that lists the packages to install?).